### PR TITLE
Optimize component styles loading from CDN

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React + TS</title>
-    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.3/dist/tailwind.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.15/dist/tailwind.min.css" rel="stylesheet">
   </head>
   <body>
     <div id="root"></div>

--- a/package.json
+++ b/package.json
@@ -10,11 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@tailwindcss/vite": "^4.1.11",
     "@vitejs/plugin-react": "^4.7.0",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0",
-    "tailwindcss": "^4.1.11"
+    "react-dom": "^19.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,3 @@
-@import "tailwindcss";
-
 :root {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,8 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
-import tailwindcss from "@tailwindcss/vite";
 
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [react()],
   build: {
     rollupOptions: {
       input: "src/widget-entry.tsx",


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Migrate Tailwind CSS from JavaScript bundling to CDN loading to reduce bundle size.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, Tailwind CSS was being bundled via a Vite plugin while an older CDN reference was also present, leading to an unnecessary increase in the JavaScript bundle size.

---

[Open in Web](https://cursor.com/agents?id=bc-d8247348-a3f1-4258-b4ab-e81aa4c86c1a) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-d8247348-a3f1-4258-b4ab-e81aa4c86c1a)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)